### PR TITLE
Removed the .user-info section in "custom.scss"

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
## Change

Remove the .user-info section in "custom.scss"

## Issue

Mobile users are unable to follow other user.

Problematic screen `/@username` because user info component, controlled via CSS, is too wide.